### PR TITLE
Correct repo name when adding remote

### DIFF
--- a/2-github.md
+++ b/2-github.md
@@ -31,7 +31,7 @@ With our local repository created, we will now push our code to GitHub.
 - Execute the following code in the Integrated Terminal
 
 ``` bash
-git remote add origin https://github.com/<REPLACE-ME>/wibble-2.git
+git remote add origin https://github.com/<REPLACE-ME>/aswa-dogs.git
 git branch -M master
 git push -u origin master
 ```


### PR DESCRIPTION
Hey Christopher,

First thanks for this great workshop!

While running through it I found a minor mixup in the repo being used when adding it as a 'remote' for git. Hope this helps!